### PR TITLE
Remove elpy dependency

### DIFF
--- a/detectors/wm/requirements.txt
+++ b/detectors/wm/requirements.txt
@@ -10,7 +10,6 @@ decorator==4.4.2
 defusedxml==0.6.0
 distlib==0.3.0
 docopt==0.6.2
-elpy==1.999
 entrypoints==0.3
 filelock==3.0.12
 flake8==3.7.9


### PR DESCRIPTION
This dependency has no functionality in it.  This package is a "tombstone package" meant to avoid broken builds. See here: https://pypi.org/project/elpy/ and here: https://github.com/jorgenschaefer/elpy/issues/1583

@gps-iqt-labs and I reviewed the dependencies in fakefinder with the lowest Snyk health scores. See below for a screenshot of our analysis.

<img width="1492" alt="Bottom10Components" src="https://user-images.githubusercontent.com/54914994/134415373-738abf16-9ad3-45b1-9cc8-17c8bde3659b.png">

If you are amenable to us removing other dependencies as fit, we are glad to help.